### PR TITLE
fix(s3): Replace static S3 paths with hsg-shell config constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build/*
-.existdb.json
-.DS_Store
+.*
+!.gitignore
 expath-pkg.xml
 repo.xml

--- a/modules/epub.xql
+++ b/modules/epub.xql
@@ -20,6 +20,7 @@ module namespace epub = "http://history.state.gov/ns/xquery/epub";
 import module namespace compression = "http://exist-db.org/xquery/compression";
 import module namespace render = "http://history.state.gov/ns/xquery/tei-render" at "tei-render.xql";
 import module namespace frus = "http://history.state.gov/ns/xquery/frus" at "frus.xql";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 
 import module namespace console="http://exist-db.org/xquery/console";
 
@@ -99,7 +100,7 @@ declare function epub:save-frus-epub-to-disk($path-to-tei-document as xs:string,
         if (util:binary-doc-available(concat($images-collection, '/', $vol-id, '.jpg'))) then
             concat($images-collection, '/', $vol-id, '.jpg')
         else
-            let $href := concat('https://s3.amazonaws.com/static.history.state.gov/frus/', $vol-id, '/covers/', $vol-id, '.jpg')
+            let $href := concat($hsg-config:S3_URL || '/frus/', $vol-id, '/covers/', $vol-id, '.jpg')
             let $request := <hc:request href="{$href}" method="head" http-version="1.1"/>
             let $response := hc:send-request($request)
             return
@@ -806,7 +807,7 @@ declare function epub:cache-all-images($text) {
                 if (util:binary-doc-available(concat($epub:cache-collection, '/', $graphic/@cache-path, '/', $graphic/@file))) then
                     concat($graphic/@cache-path, '/', $graphic/@file)
                 else
-                    let $uri := concat('https://s3.amazonaws.com/static.history.state.gov/', $graphic/@s3-path, '/', encode-for-uri($graphic/@file))
+                    let $uri := concat($hsg-config:S3_URL || '/', $graphic/@s3-path, '/', encode-for-uri($graphic/@file))
                     return
                         epub:cache-image($uri, concat($epub:cache-collection, '/', $graphic/@cache-path), $graphic/@file)
             let $path-to-cached-image := concat($epub:cache-collection, '/', $graphic-binary-uri)

--- a/modules/tei-render.xql
+++ b/modules/tei-render.xql
@@ -19,6 +19,7 @@ xquery version "3.0";
 module namespace render="http://history.state.gov/ns/xquery/tei-render";
 
 import module namespace frusx = "http://history.state.gov/ns/xquery/frus" at "frus.xql";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 import module namespace console="http://exist-db.org/xquery/console";
 import module namespace functx = "http://www.functx.com";
 
@@ -1357,7 +1358,7 @@ declare function render:pb($node as element(tei:pb), $options) as item()* {
             if ($frusx:STATIC-FILE-LOCATION eq 'local') then '/historicaldocuments/'
             else if ($frusx:STATIC-FILE-LOCATION eq 'hsg') then 'http://history.state.gov/historicaldocuments/'
             else (: if ($frus:STATIC-FILE-LOCATION eq 's3') then :)
-                'https://s3.amazonaws.com/static.history.state.gov/frus/'
+                $hsg-config:S3_URL || '/frus/'
         let $imagepath :=
             if ($frusx:STATIC-FILE-LOCATION = ('local', 'hsg')) then
                 concat($fruspageimagerelativepath, $volume, "/media/medium/")

--- a/modules/tei2fo.xq
+++ b/modules/tei2fo.xq
@@ -13,6 +13,8 @@ declare namespace tei="http://www.tei-c.org/ns/1.0";
 
 import module namespace xslfo="http://exist-db.org/xquery/xslfo";
 import module namespace frus = "http://history.state.gov/ns/xquery/frus" at "frus.xql";
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
+
 import module namespace functx = "http://www.functx.com"; 
 
 declare variable $t2f:fop-config := 
@@ -1421,7 +1423,7 @@ declare function t2f:graphic($node, $options) {
             concat($images-collection, '/', $url, '.png')
         else
             for $ext in ('svg', 'tiff', 'png')
-            let $uri := concat('https://s3.amazonaws.com/static.history.state.gov/', 'frus-history' (:'frus/', $filename :), '/', $url, '.', $ext)
+            let $uri := concat($hsg-config:S3_URL || '/', 'frus-history' (:'frus/', $filename :), '/', $url, '.', $ext)
             let $response := httpclient:head(xs:anyURI($uri), false(), ())
             return
                 if ($response/@statusCode eq '200') then 

--- a/s3-cache.xq
+++ b/s3-cache.xq
@@ -2,6 +2,7 @@ xquery version "3.0";
 
 import module namespace release = "http://history.state.gov/ns/xquery/release" at "modules/release.xql";
 import module namespace aws_config = "http://history.state.gov/ns/xquery/aws_config" at '/db/apps/s3/modules/aws_config.xqm';
+import module namespace hsg-config = "http://history.state.gov/ns/xquery/config" at '/db/apps/hsg-shell/modules/config.xqm';
 import module namespace bucket = 'http://www.xquery.co.uk/modules/connectors/aws/s3/bucket' at '/db/apps/s3/modules/xaws/modules/uk/co/xquery/www/modules/connectors/aws-exist/s3/bucket.xq';
 import module namespace frus = "http://history.state.gov/ns/site/hsg/frus-html" at "/db/apps/hsg-shell/modules/frus-html.xqm";
 
@@ -53,7 +54,7 @@ declare function local:mkcol($collection, $path) {
 (: provide this function a directory like 'frus/frus1964-68v12/ebook/' and it will update 
 the existing cache of that directory's contents :)
 declare function local:update-leaf-directory($directory as xs:string) {
-    let $bucket := 'static.history.state.gov'
+    let $bucket := $hsg-config:S3_BUCKET
     let $delimiter := '/'
     let $marker := ()
     let $max-keys := ()


### PR DESCRIPTION
* import hsg-shell config module
* replace urls to S3 with $hsg-config:S3_URL
* replace bucketname 'static.history.state.gov' with
$hsg-config:S3_BUCKET
Note: S3 references in file "modules/frus.xql" have been untouched,
since the current syntax "//s3.amazonaws.com/static.history.state.gov"
and the expected URL is unclear. ($frus:PAGEIMAGES-URL-PATH,
$frus:PDF-URL-PATH)